### PR TITLE
Abstract method getCircleColorsCount (#1892)

### DIFF
--- a/MPChartLib-Realm/src/main/java/com/github/mikephil/charting/data/realm/implementation/RealmLineDataSet.java
+++ b/MPChartLib-Realm/src/main/java/com/github/mikephil/charting/data/realm/implementation/RealmLineDataSet.java
@@ -252,6 +252,11 @@ public class RealmLineDataSet<T extends RealmObject> extends RealmLineRadarDataS
         return mCircleColors;
     }
 
+
+    public int getCircleColorCount(){
+        return mCircleColors.size();
+    }
+
     @Override
     public int getCircleColor(int index) {
         return mCircleColors.get(index % mCircleColors.size());


### PR DESCRIPTION
As part of updates to MPAndroidChart there is a new abstract method intGetCircleColorsCount() as part of LineDataSet.  Without an implementation of this method, LineChart will crash.
